### PR TITLE
feat: start work on lightswitch

### DIFF
--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -1,6 +1,6 @@
 template:
+  light-switch: true
   bootstrap: 5
-  bootswatch: flatly # https://bootswatch.com/flatly/
   bslib:
     danger: "#F8C9C4"
     success: "white"


### PR DESCRIPTION
Themes don't work with the lightswitch (https://github.com/r-lib/pkgdown/issues/2679 + I tried it here and the light theme looked awful).

From the Bootswatch flatly theme, @krlmlr what would you say defines the R-DBI "visual identity"? I know we kept https://r-dbi.org/ pretty close to the defaults.